### PR TITLE
CORS cookies and .envexample

### DIFF
--- a/.envexample
+++ b/.envexample
@@ -1,0 +1,23 @@
+###############################################################################
+# database                                                                    #
+###############################################################################
+POSTGRES_USER="{name}"
+POSTGRES_PASSWORD="{name_pass}"
+POSTGRES_DB="{name_db}"
+DB_CONTAINER="{db_container}"
+DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DB_CONTAINER}:5432/${POSTGRES_DB}?schema=public"
+
+###############################################################################
+# 42 API                                                                      #
+###############################################################################
+AUTH_URL="{auth_url}"
+TOKEN_URL="{token_url}"
+CLIENT_ID="{client_id}"
+CLIENT_SECRET="{client_secret}"
+CALLBACK_URL="{callback_url}"
+
+###############################################################################
+# MISC                                                                        #
+###############################################################################
+JWT_SECRET="{don't tell anyone my secret}"
+BACKEND_HOST="{the backend host name}"

--- a/App/src/components/LoginForm.tsx
+++ b/App/src/components/LoginForm.tsx
@@ -25,7 +25,8 @@ const LoginForm: React.FC<LoginFormProps> = ({ onLinkClick }) => {
 		try {
 			const response = await axios.post(
 				'http://localhost:3000/auth/local/login',
-				loginDTO
+				loginDTO,
+				{ withCredentials: true }
 			);
 			console.log('response other', response);
 			// Logging response for now, should redirect when React routing is implemented
@@ -49,6 +50,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onLinkClick }) => {
 		}
 	}
 
+/*
 	const handleFourtyTwo = async (e: React.MouseEvent<HTMLButtonElement>) => {
 		e.preventDefault();
 		
@@ -62,11 +64,15 @@ const LoginForm: React.FC<LoginFormProps> = ({ onLinkClick }) => {
 			console.log('error 42', error);
 		}
 	}
+*/
 
 	return (
 		<Form onSubmit={handleSubmit} loginError={loginError}>
 			<h1>Connect</h1>
-			<Button type="button" onClick={handleFourtyTwo}>Sign up with 42</Button>
+			<Button type="button">
+				<a href="http://localhost:3000/auth/fourtytwo/login">Sign up with 42</a>
+			</Button>
+
 			<p>――――― OR ――――― </p>
 			<Input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="email"/>
 			<Input type="password" value={pass} onChange={(e) => setPass(e.target.value)} placeholder="password"/>

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -28,7 +28,19 @@ export class AuthService {
       },
     });
 
-    if (!user) {
+    let email = await this.prisma.user.findUnique({
+      where: {
+        email: dto.email,
+      },
+    });
+
+    let userName = await this.prisma.user.findUnique({
+      where: {
+        userName: dto.userName,
+      },
+    });
+
+    if (!user && !email && !userName) {
       try {
         user = await this.prisma.user.create({
           data: {
@@ -41,11 +53,14 @@ export class AuthService {
           },
         });
       } catch (error) {
-        throw error;
+	      if (error.code === 'P2002') {
+		throw new ForbiddenException('Credentials taken');
+		throw error;
+	      }
       }
     }
     // const token = await this.signToken(user.id, user.email);
-    res.cookie('42accesToken', accessToken);
+    // res.cookie('42accesToken', accessToken);
 
     if (user.twoFAActivated) {
       return { redirect: '/2fa-verify' };
@@ -180,6 +195,6 @@ export class AuthService {
     })    
   
     const token = await this.signToken(user.id, user.email);
-    res.cookie('jwt', token).redirect('/hello');
+    res.cookie('jwt', token).redirect('http://localhost:8080');
   }
 }


### PR DESCRIPTION
Frontend:
- Add `withCredentials` in request option to enable CORS cookies [Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials)
- Change the "Sign up with 42" button to a simple link (Avoid CORS problem. Might have better solution witx AJAX?)

Backend:
- Set the post-login general redirection to the frontend homepage.

Others:
- Add an `.envexample`

Suggestion:
- Change the "App" folder name to "frontend" since "App" is a bit too generic.